### PR TITLE
handle already deleted resources

### DIFF
--- a/site24x7/action.go
+++ b/site24x7/action.go
@@ -119,7 +119,12 @@ func actionUpdate(d *schema.ResourceData, meta interface{}) error {
 func actionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(site24x7.Client)
 
-	return client.ITAutomations().Delete(d.Id())
+	err := client.ITAutomations().Delete(d.Id())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }
 
 func actionExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/site24x7/action_test.go
+++ b/site24x7/action_test.go
@@ -95,6 +95,10 @@ func TestActionDelete(t *testing.T) {
 	c.FakeITAutomations.On("Delete", "123").Return(nil).Once()
 
 	require.NoError(t, actionDelete(d, c))
+
+	c.FakeITAutomations.On("Delete", "123").Return(apierrors.NewStatusError(404, "not found")).Once()
+
+	require.NoError(t, actionDelete(d, c))
 }
 
 func TestActionExists(t *testing.T) {

--- a/site24x7/monitorgroup.go
+++ b/site24x7/monitorgroup.go
@@ -76,7 +76,12 @@ func monitorGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 func monitorGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(site24x7.Client)
 
-	return client.MonitorGroups().Delete(d.Id())
+	err := client.MonitorGroups().Delete(d.Id())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }
 
 func monitorGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/site24x7/monitorgroup_test.go
+++ b/site24x7/monitorgroup_test.go
@@ -81,6 +81,10 @@ func TestMonitorGroupDelete(t *testing.T) {
 	c.FakeMonitorGroups.On("Delete", "123").Return(nil).Once()
 
 	require.NoError(t, monitorGroupDelete(d, c))
+
+	c.FakeMonitorGroups.On("Delete", "123").Return(apierrors.NewStatusError(404, "not found")).Once()
+
+	require.NoError(t, monitorGroupDelete(d, c))
 }
 
 func TestMonitorGroupExists(t *testing.T) {

--- a/site24x7/websitemonitor.go
+++ b/site24x7/websitemonitor.go
@@ -190,7 +190,12 @@ func websiteMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
 func websiteMonitorDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(site24x7.Client)
 
-	return client.Monitors().Delete(d.Id())
+	err := client.Monitors().Delete(d.Id())
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }
 
 func websiteMonitorExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/site24x7/websitemonitor_test.go
+++ b/site24x7/websitemonitor_test.go
@@ -299,6 +299,10 @@ func TestWebsiteMonitorDelete(t *testing.T) {
 	c.FakeMonitors.On("Delete", "123").Return(nil).Once()
 
 	require.NoError(t, websiteMonitorDelete(d, c))
+
+	c.FakeMonitors.On("Delete", "123").Return(apierrors.NewStatusError(404, "not found")).Once()
+
+	require.NoError(t, websiteMonitorDelete(d, c))
 }
 
 func TestWebsiteMonitorExists(t *testing.T) {


### PR DESCRIPTION
Deletion should not fail if a managed resource was already manually
deleted.