### PR TITLE
prevent json null for custom_headers and action_ids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/Bonial-International-GmbH/terraform-provider-site24x7
 go 1.12
 
 require (
-	github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191011120600-568ee03b5b42
+	github.com/Bonial-International-GmbH/site24x7-go v0.0.1
 	github.com/hashicorp/terraform-plugin-sdk v1.1.1
+	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191010114601-2e6a1e4ef
 github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191010114601-2e6a1e4efcfd/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191011120600-568ee03b5b42 h1:Y9KbHsvVlxFO77eE4XcvvsSqHBJMJi2bty3f9hctKVs=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191011120600-568ee03b5b42/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191022100119-4d3bb1fd76f1 h1:I/DXwMGJ/ydCvDm48XVYSQ4u/tCHFbVPMYg+jz/2OVE=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191022100119-4d3bb1fd76f1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.1 h1:51bzdUgtWlBfjZanVHCt5gn5fIlYSX/31OhZHjFgXBA=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/site24x7/provider.go
+++ b/site24x7/provider.go
@@ -1,9 +1,12 @@
 package site24x7
 
 import (
+	"os"
+
 	site24x7 "github.com/Bonial-International-GmbH/site24x7-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	log "github.com/sirupsen/logrus"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -40,6 +43,11 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	tfLog := os.Getenv("TF_LOG")
+	if tfLog == "DEBUG" || tfLog == "TRACE" {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	config := site24x7.Config{
 		ClientID:     d.Get("oauth2_client_id").(string),
 		ClientSecret: d.Get("oauth2_client_secret").(string),

--- a/site24x7/websitemonitor_test.go
+++ b/site24x7/websitemonitor_test.go
@@ -36,6 +36,8 @@ func TestWebsiteMonitorCreate(t *testing.T) {
 					ThresholdProfileID:    "012",
 					UseNameServer:         true,
 					UserGroupIDs:          []string{"123"},
+					CustomHeaders:         []api.Header{},
+					ActionIDs:             []api.ActionRef{},
 				}
 
 				c.FakeMonitors.On("Create", a).Return(a, nil).Once()
@@ -401,6 +403,8 @@ func TestResourceDataToWebsiteMonitor(t *testing.T) {
 				ThresholdProfileID:    "012",
 				UseNameServer:         true,
 				UserGroupIDs:          []string{"123"},
+				CustomHeaders:         []api.Header{},
+				ActionIDs:             []api.ActionRef{},
 			},
 		},
 		{
@@ -432,6 +436,8 @@ func TestResourceDataToWebsiteMonitor(t *testing.T) {
 				ThresholdProfileID:    "012",
 				UseNameServer:         true,
 				UserGroupIDs:          []string{"123"},
+				CustomHeaders:         []api.Header{},
+				ActionIDs:             []api.ActionRef{},
 			},
 		},
 		{
@@ -480,6 +486,8 @@ func TestResourceDataToWebsiteMonitor(t *testing.T) {
 				ThresholdProfileID:    "012",
 				UseNameServer:         true,
 				UserGroupIDs:          []string{"123"},
+				CustomHeaders:         []api.Header{},
+				ActionIDs:             []api.ActionRef{},
 			},
 		},
 		{
@@ -511,6 +519,8 @@ func TestResourceDataToWebsiteMonitor(t *testing.T) {
 				ThresholdProfileID:    "345",
 				UseNameServer:         true,
 				UserGroupIDs:          []string{"123"},
+				CustomHeaders:         []api.Header{},
+				ActionIDs:             []api.ActionRef{},
 			},
 		},
 		{
@@ -542,6 +552,8 @@ func TestResourceDataToWebsiteMonitor(t *testing.T) {
 				ThresholdProfileID:    "345",
 				UseNameServer:         true,
 				UserGroupIDs:          []string{"345"},
+				CustomHeaders:         []api.Header{},
+				ActionIDs:             []api.ActionRef{},
 			},
 		},
 	}


### PR DESCRIPTION
This also adds a switch that will enabled site24x7 debug logging when
`TF_LOG` is set to `DEBUG` or `TRACE`.