### PR TITLE
add configuration for goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cover
 .terraform
+/dist
 /vendor
 coverage.txt
 terraform-provider-site24x7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+---
+project_name: terraform-provider-site24x7
+builds:
+  - main: ./main.go
+    binary: terraform-provider-site24x7
+    ldflags:
+      - -s -w
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - 386
+      - amd64
+archives:
+  - format: binary
+    files:
+      - none*
+    replacements:
+      386: i386
+      amd64: x86_64
+release:
+  github:
+    owner: martinohmann
+    name: terraform-provider-site24x7
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,10 @@ cache:
 script:
   - make coverage
   - make lint
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true
+      condition: $TRAVIS_OS_NAME = linux && $TRAVIS_GO_VERSION =~ ^1\.12


### PR DESCRIPTION
This adds the necessary configuration to automatically build the
provider binaries for linux and macos and attach them to every tagged
release.