### PR TITLE
add retry config attributes to the provider

### DIFF
--- a/_examples/main.tf
+++ b/_examples/main.tf
@@ -11,6 +11,17 @@ provider "site24x7" {
   // The refresh token will be looked up in the SITE24X7_OAUTH2_REFRESH_TOKEN
   // environment variable if the attribute is empty or omitted.
   oauth2_refresh_token = "${var.oauth2_refresh_token}"
+
+  // The minimum time to wait in seconds before retrying failed Site24x7 API requests.
+  retry_min_wait = 1
+
+  // The maximum time to wait in seconds before retrying failed Site24x7 API
+  // requests. This is the upper limit for the wait duration with exponential
+  // backoff.
+  retry_max_wait = 30
+
+  // Maximum number of Site24x7 API request retries to perform until giving up.
+  max_retries = 4
 }
 
 // IT Automation API doc: https://www.site24x7.com/help/api/#it-automation

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Bonial-International-GmbH/terraform-provider-site24x7
 go 1.12
 
 require (
-	github.com/Bonial-International-GmbH/site24x7-go v0.0.1
+	github.com/Bonial-International-GmbH/site24x7-go v0.0.3
 	github.com/hashicorp/terraform-plugin-sdk v1.1.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191022100119-4d3bb1fd7
 github.com/Bonial-International-GmbH/site24x7-go v0.0.0-20191022100119-4d3bb1fd76f1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.1 h1:51bzdUgtWlBfjZanVHCt5gn5fIlYSX/31OhZHjFgXBA=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.3 h1:dxJg9+YNE4/n3+s161vooEs1ne6VWzvhfD/yqx918ZM=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.3/go.mod h1:t8PPOZgtwUCU9xodDhmt5ATqTHkIQgyzCkgjze7zz90=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -64,6 +66,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
This adds retry configuration attributes to the provider to be able to
configure the retry behaviour of the Site24x7 API client.

It also updates the API client to the latest version.