### PR TITLE
bump site24x7-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Bonial-International-GmbH/terraform-provider-site24x7
 go 1.12
 
 require (
-	github.com/Bonial-International-GmbH/site24x7-go v0.0.3
+	github.com/Bonial-International-GmbH/site24x7-go v0.0.4
 	github.com/hashicorp/terraform-plugin-sdk v1.1.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/Bonial-International-GmbH/site24x7-go v0.0.1 h1:51bzdUgtWlBfjZanVHCt5
 github.com/Bonial-International-GmbH/site24x7-go v0.0.1/go.mod h1:VlIGpD11eJjemyS+Rmh4pd9bhAwYuXFemVO+nL6OSqs=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.3 h1:dxJg9+YNE4/n3+s161vooEs1ne6VWzvhfD/yqx918ZM=
 github.com/Bonial-International-GmbH/site24x7-go v0.0.3/go.mod h1:t8PPOZgtwUCU9xodDhmt5ATqTHkIQgyzCkgjze7zz90=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.4 h1:QBhopy/qCoqmuLFkCa6y3qgg0m1EC5qpUecLQrqTLOM=
+github.com/Bonial-International-GmbH/site24x7-go v0.0.4/go.mod h1:t8PPOZgtwUCU9xodDhmt5ATqTHkIQgyzCkgjze7zz90=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=


### PR DESCRIPTION
This bumps the version of site24x7 to upstream the bugfix made in
https://github.com/Bonial-International-GmbH/site24x7-go/pull/30

This fixes: https://github.com/Bonial-International-GmbH/terraform-provider-site24x7/issues/19.