### PR TITLE
chore: move catalog-info.yaml to repo root

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   description:
     An open source terrafrom provider for site24x7
   annotations:
-    backstage.io/techdocs-ref: dir:..
+    backstage.io/techdocs-ref: dir:.
   links:
     - url: https://site24x7.com
     - url: https://registry.terraform.io/providers/Bonial-International-GmbH/site24x7/latest


### PR DESCRIPTION
We decided to go with the default location as this will avoid some
issues with the source location and relative plugin-specific links in
annotations.